### PR TITLE
Add request_id to requests and log

### DIFF
--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -4,7 +4,7 @@ BIN_NAME := gateway
 
 .PHONY: run dev test testdev build
 run:
-	go run ./cmd/gateway
+	@go run ./cmd/gateway
 
 dev:
 	@find . -name '*.go' ! -name '*_test.go' | entr -r go run ./cmd/gateway

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,8 @@ module github.com/ratdaddy/blockcloset/gateway
 go 1.24
 
 require (
-	github.com/go-chi/chi/v5 v5.2.2 // indirect
-	github.com/go-chi/httplog/v3 v3.2.2 // indirect
-	github.com/lmittmann/tint v1.1.2 // indirect
+	github.com/go-chi/chi/v5 v5.2.2
+	github.com/go-chi/httplog/v3 v3.2.2
+	github.com/lmittmann/tint v1.1.2
+	github.com/oklog/ulid/v2 v2.1.1
 )

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -4,3 +4,6 @@ github.com/go-chi/httplog/v3 v3.2.2 h1:G0oYv3YYcikNjijArHFUlqfR78cQNh9fGT43i6Stq
 github.com/go-chi/httplog/v3 v3.2.2/go.mod h1:N/J1l5l1fozUrqIVuT8Z/HzNeSy8TF2EFyokPLe6y2w=
 github.com/lmittmann/tint v1.1.2 h1:2CQzrL6rslrsyjqLDwD11bZ5OpLBPU+g3G/r5LSfS8w=
 github.com/lmittmann/tint v1.1.2/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/gateway/internal/httpapi/create_bucket.go
+++ b/gateway/internal/httpapi/create_bucket.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
 	"github.com/ratdaddy/blockcloset/gateway/internal/logger"
 	"github.com/ratdaddy/blockcloset/gateway/internal/respond"
 )

--- a/gateway/internal/httpapi/request_id.go
+++ b/gateway/internal/httpapi/request_id.go
@@ -1,0 +1,68 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rand"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/httplog/v3"
+	"github.com/oklog/ulid/v2"
+
+	"github.com/ratdaddy/blockcloset/gateway/internal/config"
+)
+
+type ctxKey int
+
+const (
+	ctxKeyID        ctxKey = iota
+	headerRequestID        = "X-Request-ID"
+	otelKey                = "http.request.header.x-request-id"
+)
+
+var (
+	ulidMu      sync.Mutex
+	ulidEntropy = ulid.Monotonic(rand.Reader, 0) // monotonic across same ms
+)
+
+func Get(ctx context.Context) string {
+	id, _ := ctx.Value(ctxKeyID).(string)
+	return id
+}
+
+func defaultID() string {
+	ulidMu.Lock()
+	id := ulid.MustNew(ulid.Timestamp(time.Now()), ulidEntropy)
+	ulidMu.Unlock()
+	return id.String() // 26 chars, Crockford base32
+}
+
+func RequestID() func(http.Handler) http.Handler {
+	safe := regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var id string
+			if v := strings.TrimSpace(r.Header.Get(headerRequestID)); safe.MatchString(v) {
+				id = v
+			}
+			if id == "" {
+				id = defaultID()
+			}
+
+			ctx := context.WithValue(r.Context(), ctxKeyID, id)
+			r.Header.Set(headerRequestID, id)
+			w.Header().Set(headerRequestID, id)
+
+			if config.LogVerbosity == config.LogVerbose {
+				httplog.SetAttrs(ctx, slog.String(otelKey, id))
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/gateway/internal/httpapi/request_id_test.go
+++ b/gateway/internal/httpapi/request_id_test.go
@@ -1,0 +1,210 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/httplog/v3"
+
+	"github.com/ratdaddy/blockcloset/gateway/internal/config"
+)
+
+type captureHandler struct {
+	mu      sync.Mutex
+	records []map[string]any
+	level   slog.Leveler
+}
+
+func (h *captureHandler) Records() []map[string]any {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if len(h.records) == 0 {
+		return nil
+	}
+	prefix := h.records[0]
+	out := make([]map[string]any, 0, len(h.records))
+	for i, rec := range h.records {
+		if i == 0 && prefix != nil {
+			continue
+		}
+		m := make(map[string]any, len(prefix)+len(rec))
+		maps.Copy(m, prefix)
+		maps.Copy(m, rec)
+		out = append(out, m)
+	}
+	return out
+}
+
+func parseJSONStream(t *testing.T, r io.Reader) []map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(r)
+
+	var out []map[string]any
+	for {
+		var m map[string]any
+		if err := dec.Decode(&m); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("bad json log: %v", err)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func exercise(t *testing.T, req *http.Request) (*httptest.ResponseRecorder, string, []map[string]any) {
+	t.Helper()
+	config.LogVerbosity = config.LogVerbose
+
+	var observedID string
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observedID = Get(r.Context())
+		if observedID == "" {
+			t.Fatalf("expected request id in context")
+		}
+		if got := r.Header.Get("X-Request-ID"); got != observedID {
+			t.Fatalf("expected r.Header[X-Request-ID]=%q, got %q", observedID, got)
+		}
+		_, _ = io.WriteString(w, observedID)
+	})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	chain := RequestID()(h)
+	chain = httplog.RequestLogger(logger, nil)(chain)
+
+	rr := httptest.NewRecorder()
+	chain.ServeHTTP(rr, req)
+
+	return rr, observedID, parseJSONStream(t, &buf)
+
+}
+
+func TestMiddleware_Defaults_Table(t *testing.T) {
+	safeRe := regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+	ulidRe := regexp.MustCompile(`^[0-9A-HJKMNP-TV-Z]{26}$`)
+
+	tests := []struct {
+		name           string
+		inHeader       string
+		wantUseInbound bool
+		wantGenerated  bool
+	}{
+		{
+			name:           "uses_well_formed_inbound_header",
+			inHeader:       "req_abc-123.DEF",
+			wantUseInbound: true,
+		},
+		{
+			name:          "generates_when_missing",
+			inHeader:      "",
+			wantGenerated: true,
+		},
+		{
+			name:          "rejects_unsafe_inbound_and_generates",
+			inHeader:      "bad\nheader",
+			wantGenerated: true,
+		},
+		{
+			name:           "trims_and_uses_inbound_if_safe_after_trim",
+			inHeader:       "   abc_DEF-123   ",
+			wantUseInbound: true,
+		},
+		{
+			name:          "rejects_too_long_inbound",
+			inHeader:      strings.Repeat("a", 129),
+			wantGenerated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://example.test/ok", nil)
+			if tt.inHeader != "" {
+				req.Header.Set("X-Request-ID", tt.inHeader)
+			}
+
+			rr, observed, logs := exercise(t, req)
+
+			gotHeader := rr.Header().Get("X-Request-ID")
+			if gotHeader == "" {
+				t.Fatalf("expected response X-Request-ID header to be set")
+			}
+
+			body := strings.TrimSpace(rr.Body.String())
+			if body == "" {
+				t.Fatalf("expected body to contain observed id")
+			}
+
+			if observed != gotHeader || observed != body {
+				t.Fatalf("id mismatch: observed=%q respHeader=%q body=%q", observed, gotHeader, body)
+			}
+
+			if !safeRe.MatchString(observed) {
+				t.Fatalf("resulting id %q does not match safe charset", observed)
+			}
+
+			switch {
+			case tt.wantUseInbound:
+				want := strings.TrimSpace(tt.inHeader)
+				if observed != want {
+					t.Fatalf("expected to use inbound id %q, got %q", want, observed)
+				}
+			case tt.wantGenerated:
+				if !ulidRe.MatchString(observed) {
+					t.Fatalf("expected generated ksuid id (26 chars, Crockford Base32), got %q", observed)
+				}
+				if tt.inHeader != "" && strings.TrimSpace(tt.inHeader) == observed {
+					t.Fatalf("expected generated id to differ from unsafe inbound, got same %q", observed)
+				}
+			default:
+				t.Fatalf("test case must set wantUseInbound or wantGenerated")
+			}
+
+			found := false
+			for _, rec := range logs {
+				if v, ok := rec[otelKey]; ok {
+					if s, ok := v.(string); ok && s == observed {
+						found = true
+						break
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("expected at least one log record with %s=%q; got %+v", otelKey, observed, logs)
+			}
+		})
+	}
+}
+
+func TestMiddleware_GenerationProducesDifferentIDs(t *testing.T) {
+	req1 := httptest.NewRequest(http.MethodGet, "http://example.test/a", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "http://example.test/b", nil)
+
+	rr1, id1, _ := exercise(t, req1)
+	_, id2, _ := exercise(t, req2)
+
+	if id1 == id2 {
+		t.Fatalf("expected different generated ids; got same %q", id1)
+	}
+	if !(id1 < id2) {
+		t.Fatalf("expected ULIDs to sort by time: %s !< %s", id1, id2)
+	}
+	if rr1.Header().Get("X-Request-ID") != id1 {
+		t.Fatalf("response header should echo id1")
+	}
+}

--- a/gateway/internal/httpapi/router_chi.go
+++ b/gateway/internal/httpapi/router_chi.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+
 	"github.com/ratdaddy/blockcloset/gateway/internal/logger"
 	"github.com/ratdaddy/blockcloset/gateway/internal/respond"
 )
@@ -15,7 +16,10 @@ type BucketHandlers interface {
 
 func NewRouter(h BucketHandlers) http.Handler {
 	mux := chi.NewRouter()
+
 	mux.Use(logger.RequestLogger)
+
+	mux.Use(RequestID())
 
 	mux.Use(middleware.StripSlashes)
 

--- a/gateway/internal/logger/request_logger.go
+++ b/gateway/internal/logger/request_logger.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"context"
 	"log/slog"
 	"net/http"
 
@@ -9,13 +8,6 @@ import (
 
 	"github.com/ratdaddy/blockcloset/gateway/internal/config"
 )
-
-type ctxWriter struct {
-	http.ResponseWriter
-	ctx context.Context
-}
-
-func (w *ctxWriter) Context() context.Context { return w.ctx }
 
 var RequestLogger = func(next http.Handler) http.Handler {
 	var sc *httplog.Schema


### PR DESCRIPTION
# Problem

When we start logging how requests get processed throughout the system it would be good to be able to tie all the logs for a particular request together.

# Solution

Add a request id to request readers and writers and put it in request logging. Set it when a request arrives if there is no other request id.