### PR TITLE
Add schema to loggrpc to control log key names

### DIFF
--- a/gantry/cmd/gantry/main.go
+++ b/gantry/cmd/gantry/main.go
@@ -36,10 +36,11 @@ func main() {
 	}
 
 	logger := slog.Default()
-	s := grpc.NewServer(grpc.UnaryInterceptor(loggrpc.UnaryServerInterceptor(logger)))
+	s := grpc.NewServer(grpc.UnaryInterceptor(loggrpc.UnaryServerInterceptor(logger, &loggrpc.Options{
+		Schema: loggrpc.SchemaOTEL.Concise(config.LogVerbosity == config.LogConcise),
+	})))
 
 	grpcsvc.Register(s, grpcsvc.New(logger))
-
 	if config.EnableReflection {
 		slog.Info("grpc reflection enabled")
 		reflection.Register(s)

--- a/gantry/internal/grpcsvc/service.go
+++ b/gantry/internal/grpcsvc/service.go
@@ -2,12 +2,14 @@ package grpcsvc
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/ratdaddy/blockcloset/loggrpc"
 	bucketv1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/bucket/v1"
 	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
 )
@@ -26,15 +28,17 @@ func Register(s *grpc.Server, svc *Service) {
 }
 
 func (s *Service) CreateBucket(ctx context.Context, req *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error) {
-	s.log.Info("CreateBucket called", "name", req.GetName())
+	bucket := req.GetName()
 
-	if req.GetName() == "bad" {
-		return nil, status.Errorf(codes.InvalidArgument, "bucket name %q is not allowed", req.GetName())
+	if bucket == "bad" {
+		return nil, status.Errorf(codes.InvalidArgument, "bucket name %q is not allowed", bucket)
 	}
+
+	loggrpc.SetAttrs(ctx, slog.String("result", fmt.Sprintf("bucket <%s> created", bucket)))
 
 	return &servicev1.CreateBucketResponse{
 		Bucket: &bucketv1.Bucket{
-			Name: req.GetName(),
+			Name: bucket,
 		},
 	}, nil
 }

--- a/gateway/internal/logger/request_logger.go
+++ b/gateway/internal/logger/request_logger.go
@@ -10,18 +10,10 @@ import (
 )
 
 var RequestLogger = func(next http.Handler) http.Handler {
-	var sc *httplog.Schema
-
-	if config.LogVerbosity == config.LogConcise {
-		sc = httplog.SchemaOTEL.Concise(true)
-	} else {
-		sc = httplog.SchemaOTEL
-	}
-
 	logger := slog.Default()
 
 	return httplog.RequestLogger(logger, &httplog.Options{
-		Schema:        sc,
+		Schema:        httplog.SchemaOTEL.Concise(config.LogVerbosity == config.LogConcise),
 		RecoverPanics: true,
 	})(next)
 }

--- a/loggrpc/context.go
+++ b/loggrpc/context.go
@@ -1,0 +1,38 @@
+package loggrpc
+
+import (
+	"context"
+	"log/slog"
+)
+
+const (
+	ErrorKey = "error"
+)
+
+type ctxKeyLogAttrs struct{}
+
+func (c *ctxKeyLogAttrs) String() string {
+	return "httplog attrs context"
+}
+
+func SetAttrs(ctx context.Context, attrs ...slog.Attr) {
+	if ptr, ok := ctx.Value(ctxKeyLogAttrs{}).(*[]slog.Attr); ok && ptr != nil {
+		*ptr = append(*ptr, attrs...)
+	}
+}
+
+func getAttrs(ctx context.Context) []slog.Attr {
+	if ptr, ok := ctx.Value(ctxKeyLogAttrs{}).(*[]slog.Attr); ok && ptr != nil {
+		return *ptr
+	}
+
+	return nil
+}
+
+func SetError(ctx context.Context, err error) error {
+	if err != nil {
+		SetAttrs(ctx, slog.Any(ErrorKey, err))
+	}
+
+	return err
+}

--- a/loggrpc/schema.go
+++ b/loggrpc/schema.go
@@ -1,0 +1,47 @@
+package loggrpc
+
+type Options struct {
+	Schema *Schema
+}
+
+type Schema struct {
+	FullMethod    string
+	Service       string
+	Method        string
+	System        string
+	Code          string
+	Protocol      string
+	Duration      string
+	RemoteIP      string
+	Scheme        string
+	Host          string
+	UserAgent     string
+	RequestBytes  string
+	ResponseBytes string
+}
+
+var (
+	SchemaOTEL = &Schema{
+		FullMethod:    "rpc.full_method",
+		Service:       "rpc.service",
+		Method:        "rpc.method",
+		System:        "rpc.system",
+		Code:          "grpc.code",
+		Protocol:      "network.protocol.version",
+		Duration:      "rpc.server.duration",
+		RemoteIP:      "client.address",
+		Scheme:        "url.scheme",
+		Host:          "server.address",
+		UserAgent:     "user_agent.original",
+		RequestBytes:  "rpc.request.size",
+		ResponseBytes: "rpc.response.size",
+	}
+)
+
+func (s *Schema) Concise(concise bool) *Schema {
+	if !concise {
+		return s
+	}
+
+	return &Schema{}
+}


### PR DESCRIPTION
# Problem

To have httplog-like logging one of the key features we want is the ability to change the log key names depending on the intended log collector the app is targeting (e.g. OTEL). We also want a way to shorten that log output for development logging and finally, we want a way to insert log key/values of our own inside our application code.

# Solution

Implement a schema feature for loggrpc mimicking httplog's. For now, describe the OTEL-style log keys. Also, add a `Concise` function and mechanism to strip log key/values out of a log entry. Finally, create a way to add log attributes to the context passed into the handler function.