### PR TITLE
Add contract test for client create_bucket

### DIFF
--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/ratdaddy/blockcloset/proto v0.0.0
 	google.golang.org/grpc v1.75.1
+	google.golang.org/protobuf v1.36.9
 )
 
 require (
@@ -16,7 +17,6 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/protobuf v1.36.9 // indirect
 )
 
 replace github.com/ratdaddy/blockcloset/proto => ../proto

--- a/gateway/internal/gantry/client_test.go
+++ b/gateway/internal/gantry/client_test.go
@@ -2,60 +2,17 @@ package gantry
 
 import (
 	"context"
-	"net"
 	"testing"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/test/bufconn"
-
 	"github.com/ratdaddy/blockcloset/gateway/internal/httpapi"
-	bucketv1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/bucket/v1"
-	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
 )
-
-const bufSize = 1024 * 1024
-
-type captureService struct {
-	servicev1.UnimplementedGantryServiceServer
-	lastIDs []string
-}
-
-func (s *captureService) CreateBucket(ctx context.Context, req *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error) {
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		s.lastIDs = append([]string{}, md.Get("x-request-id")...)
-	} else {
-		s.lastIDs = nil
-	}
-	return &servicev1.CreateBucketResponse{Bucket: &bucketv1.Bucket{Name: req.GetName()}}, nil
-}
 
 func TestClientRequestIDPropagation(t *testing.T) {
 	t.Parallel()
 
-	lis := bufconn.Listen(bufSize)
-	srv := grpc.NewServer()
-	svc := &captureService{}
-	servicev1.RegisterGantryServiceServer(srv, svc)
+	client, svc := newTestClient(t)
 
-	go func() {
-		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
-			panic(err)
-		}
-	}()
-	t.Cleanup(func() { srv.Stop() })
-
-	client, err := New(context.Background(), "passthrough:///bufnet", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-		return lis.DialContext(ctx)
-	}))
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := client.Close(); err != nil {
-			t.Fatalf("Close: %v", err)
-		}
-	})
+	const bucketName = "case-bucket"
 
 	cases := []struct {
 		name string
@@ -76,13 +33,18 @@ func TestClientRequestIDPropagation(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc.lastIDs = nil
+			svc.Reset()
 
-			if _, err := client.CreateBucket(tc.ctx(t), "case-bucket"); err != nil {
+			if _, err := client.CreateBucket(tc.ctx(t), bucketName); err != nil {
 				t.Fatalf("CreateBucket: %v", err)
 			}
 
-			got := svc.lastIDs
+			call, ok := svc.LastCreateBucketCall()
+			if !ok {
+				t.Fatalf("expected CreateBucket call")
+			}
+
+			got := call.Metadata.Get("x-request-id")
 
 			if len(got) != len(tc.want) {
 				t.Fatalf("request id count: got %d want %d (values %v)", len(got), len(tc.want), got)

--- a/gateway/internal/gantry/create_bucket_test.go
+++ b/gateway/internal/gantry/create_bucket_test.go
@@ -1,0 +1,35 @@
+package gantry
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestClientCreateBucket(t *testing.T) {
+	t.Parallel()
+
+	client, svc := newTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	const bucketName = "client-create-bucket"
+
+	gotName, err := client.CreateBucket(ctx, bucketName)
+	if err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if gotName != bucketName {
+		t.Fatalf("CreateBucket returned %q, want %q", gotName, bucketName)
+	}
+
+	calls := svc.CreateBucketCalls()
+	if len(calls) != 1 {
+		t.Fatalf("CreateBucket call count = %d, want 1", len(calls))
+	}
+
+	if calls[0].Request.GetName() != bucketName {
+		t.Fatalf("CreateBucket request Name = %q, want %q", calls[0].Request.GetName(), bucketName)
+	}
+}

--- a/gateway/internal/gantry/test_helpers_test.go
+++ b/gateway/internal/gantry/test_helpers_test.go
@@ -1,0 +1,120 @@
+package gantry
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
+
+	bucketv1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/bucket/v1"
+	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
+)
+
+const testBufConnSize = 1024 * 1024
+
+type createBucketCall struct {
+	Metadata metadata.MD
+	Request  *servicev1.CreateBucketRequest
+}
+
+type captureGantryService struct {
+	servicev1.UnimplementedGantryServiceServer
+
+	mu                 sync.Mutex
+	createBucketCalls  []createBucketCall
+	createBucketHookFn func(context.Context, *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error)
+}
+
+func newCaptureGantryService() *captureGantryService {
+	return &captureGantryService{}
+}
+
+func (s *captureGantryService) Reset() {
+	s.mu.Lock()
+	s.createBucketCalls = nil
+	s.mu.Unlock()
+}
+
+func (s *captureGantryService) CreateBucketCalls() []createBucketCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	calls := make([]createBucketCall, len(s.createBucketCalls))
+	copy(calls, s.createBucketCalls)
+	return calls
+}
+
+func (s *captureGantryService) LastCreateBucketCall() (createBucketCall, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.createBucketCalls) == 0 {
+		return createBucketCall{}, false
+	}
+	return s.createBucketCalls[len(s.createBucketCalls)-1], true
+}
+
+func (s *captureGantryService) SetCreateBucketHook(fn func(context.Context, *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error)) {
+	s.mu.Lock()
+	s.createBucketHookFn = fn
+	s.mu.Unlock()
+}
+
+func (s *captureGantryService) CreateBucket(ctx context.Context, req *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error) {
+	call := createBucketCall{
+		Request: proto.Clone(req).(*servicev1.CreateBucketRequest),
+	}
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		call.Metadata = md.Copy()
+	}
+
+	s.mu.Lock()
+	s.createBucketCalls = append(s.createBucketCalls, call)
+	hook := s.createBucketHookFn
+	s.mu.Unlock()
+
+	if hook != nil {
+		return hook(ctx, req)
+	}
+
+	return &servicev1.CreateBucketResponse{Bucket: &bucketv1.Bucket{Name: req.GetName()}}, nil
+}
+
+func newTestClient(t *testing.T) (*Client, *captureGantryService) {
+	t.Helper()
+
+	lis := bufconn.Listen(testBufConnSize)
+	srv := grpc.NewServer()
+	svc := newCaptureGantryService()
+	servicev1.RegisterGantryServiceServer(srv, svc)
+
+	go func() {
+		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+			panic(err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	client, err := New(context.Background(), "passthrough:///bufnet", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+
+	return client, svc
+}


### PR DESCRIPTION
# Problem

We didn't have any contract tests around the create bucket gateway client call code to gantry.

# Solution

Create a new test for that. Also, refactor out the client call capture test code to a common test helper file.