### PR TITLE
Validate bucket name in gantry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: ci
 on:
   push:
     branches: [ main ]
-    paths: [ "gateway/**", "gantry/**", "proto/**", "loggrpc/**", ".github/workflows/ci.yml" ]
+    paths: [ "gateway/**", "gantry/**", "proto/**", "loggrpc/**", "pkg/**", ".github/workflows/ci.yml" ]
   pull_request:
-    paths: [ "gateway/**", "gantry/**", "proto/**", "loggrpc/**", ".github/workflows/ci.yml" ]
+    paths: [ "gateway/**", "gantry/**", "proto/**", "loggrpc/**", "pkg/**", ".github/workflows/ci.yml" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        module: [ 'gantry', 'gateway' ]
+        module: [ 'gantry', 'gateway', 'pkg' ]
     defaults:
       run:
         working-directory: ${{ matrix.module }}

--- a/gantry/go.mod
+++ b/gantry/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/lmittmann/tint v1.1.2
 	github.com/ratdaddy/blockcloset/loggrpc v0.0.0
+	github.com/ratdaddy/blockcloset/pkg v0.0.0
 	github.com/ratdaddy/blockcloset/proto v0.0.0
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.8
@@ -21,3 +22,5 @@ require (
 replace github.com/ratdaddy/blockcloset/loggrpc => ../loggrpc
 
 replace github.com/ratdaddy/blockcloset/proto => ../proto
+
+replace github.com/ratdaddy/blockcloset/pkg => ../pkg

--- a/gantry/internal/grpcsvc/create_bucket.go
+++ b/gantry/internal/grpcsvc/create_bucket.go
@@ -1,0 +1,44 @@
+package grpcsvc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ratdaddy/blockcloset/loggrpc"
+	"github.com/ratdaddy/blockcloset/pkg/storage/bucket"
+	bucketv1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/bucket/v1"
+	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
+)
+
+func (s *Service) CreateBucket(ctx context.Context, req *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error) {
+	name := req.GetName()
+
+	validator := s.validator
+	if validator == nil {
+		validator = bucket.DefaultBucketNameValidator{}
+	}
+
+	if err := validator.ValidateBucketName(name); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if name == "bad" {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid bucket name")
+	}
+
+	if name == "panic" {
+		panic(status.New(codes.Internal, "intentional test panic"))
+	}
+
+	loggrpc.SetAttrs(ctx, slog.String("result", fmt.Sprintf("bucket <%s> created", name)))
+
+	return &servicev1.CreateBucketResponse{
+		Bucket: &bucketv1.Bucket{
+			Name: name,
+		},
+	}, nil
+}

--- a/gantry/internal/grpcsvc/create_bucket_test.go
+++ b/gantry/internal/grpcsvc/create_bucket_test.go
@@ -1,0 +1,85 @@
+package grpcsvc_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ratdaddy/blockcloset/gantry/internal/grpcsvc"
+	"github.com/ratdaddy/blockcloset/pkg/storage/bucket"
+	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
+)
+
+func TestService_CreateBucket(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	svc := grpcsvc.New(logger)
+
+	type tc struct {
+		name    string
+		bucket  string
+		wantErr bool
+		code    codes.Code
+		message string
+	}
+
+	cases := []tc{
+		{
+			name:   "valid bucket",
+			bucket: "my-bucket-123",
+		},
+		{
+			name:    "invalid bucket",
+			bucket:  "Bad!Name",
+			wantErr: true,
+			code:    codes.InvalidArgument,
+			message: bucket.ErrInvalidBucketName.Error(),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp, err := svc.CreateBucket(context.Background(), &servicev1.CreateBucketRequest{Name: c.bucket})
+
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil")
+				}
+
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("want gRPC status error, got %v", err)
+				}
+
+				if st.Code() != c.code {
+					t.Fatalf("status code: got %v, want %v", st.Code(), c.code)
+				}
+
+				if st.Message() != c.message {
+					t.Fatalf("status message: got %q, want %q", st.Message(), c.message)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("want nil error, got %v", err)
+			}
+
+			if resp == nil || resp.GetBucket() == nil {
+				t.Fatalf("response bucket missing: %#v", resp)
+			}
+
+			if resp.GetBucket().GetName() != c.bucket {
+				t.Fatalf("bucket name: got %q, want %q", resp.GetBucket().GetName(), c.bucket)
+			}
+		})
+	}
+}

--- a/gantry/internal/grpcsvc/service.go
+++ b/gantry/internal/grpcsvc/service.go
@@ -1,48 +1,27 @@
 package grpcsvc
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
-	"github.com/ratdaddy/blockcloset/loggrpc"
-	bucketv1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/bucket/v1"
+	"github.com/ratdaddy/blockcloset/pkg/storage/bucket"
 	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
 )
 
 type Service struct {
 	servicev1.UnimplementedGantryServiceServer
-	log *slog.Logger
+	log       *slog.Logger
+	validator bucket.BucketNameValidator
 }
 
 func New(log *slog.Logger) *Service {
-	return &Service{log: log}
+	return &Service{
+		log:       log,
+		validator: bucket.DefaultBucketNameValidator{},
+	}
 }
 
 func Register(s *grpc.Server, svc *Service) {
 	servicev1.RegisterGantryServiceServer(s, svc)
-}
-
-func (s *Service) CreateBucket(ctx context.Context, req *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error) {
-	bucket := req.GetName()
-
-	if bucket == "bad" {
-		return nil, status.Errorf(codes.InvalidArgument, "bucket name %q is not allowed", bucket)
-	}
-
-	if bucket == "panic" {
-		panic(status.New(codes.Internal, "intentional test panic"))
-	}
-
-	loggrpc.SetAttrs(ctx, slog.String("result", fmt.Sprintf("bucket <%s> created", bucket)))
-
-	return &servicev1.CreateBucketResponse{
-		Bucket: &bucketv1.Bucket{
-			Name: bucket,
-		},
-	}, nil
 }

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/httplog/v3 v3.2.2
 	github.com/lmittmann/tint v1.1.2
 	github.com/oklog/ulid/v2 v2.1.1
+	github.com/ratdaddy/blockcloset/pkg v0.0.0
 	github.com/ratdaddy/blockcloset/proto v0.0.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.9
@@ -20,3 +21,5 @@ require (
 )
 
 replace github.com/ratdaddy/blockcloset/proto => ../proto
+
+replace github.com/ratdaddy/blockcloset/pkg => ../pkg

--- a/gateway/internal/httpapi/create_bucket_test.go
+++ b/gateway/internal/httpapi/create_bucket_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ratdaddy/blockcloset/gateway/internal/httpapi"
 	_ "github.com/ratdaddy/blockcloset/gateway/internal/testutil"
+	"github.com/ratdaddy/blockcloset/pkg/storage/bucket"
 	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -85,11 +86,11 @@ func TestCreateBucket_ValidationGantryAndResponse(t *testing.T) {
 		{
 			name:         "invalid bucket -> 400",
 			bucket:       "Bad!Name",
-			validatorErr: httpapi.ErrInvalidBucketName,
+			validatorErr: bucket.ErrInvalidBucketName,
 			gantryErr:    nil,
 			wantStatus:   http.StatusBadRequest,
 			wantLoc:      "",
-			wantBodySub:  httpapi.ErrInvalidBucketName.Error(),
+			wantBodySub:  bucket.ErrInvalidBucketName.Error(),
 		},
 		{
 			name:         "gantry internal error -> 500",

--- a/gateway/internal/httpapi/handlers.go
+++ b/gateway/internal/httpapi/handlers.go
@@ -1,20 +1,24 @@
 package httpapi
 
-import "context"
+import (
+	"context"
+
+	"github.com/ratdaddy/blockcloset/pkg/storage/bucket"
+)
 
 type GantryClient interface {
 	CreateBucket(ctx context.Context, name string) (string, error)
 }
 
 type Handlers struct {
-	Validator BucketNameValidator
+	Validator bucket.BucketNameValidator
 	Gantry    GantryClient
 }
 
 func NewHandlers(g GantryClient) *Handlers {
 	// panic if no gantry client provided
 	return &Handlers{
-		Validator: DefaultBucketNameValidator{},
+		Validator: bucket.DefaultBucketNameValidator{},
 		Gantry:    g,
 	}
 }

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,0 +1,11 @@
+SHELL := /bin/bash
+
+.PHONY: test lint tidy
+
+test:
+	go test ./...
+
+testdev:
+	@find . -type f -name '*.go' '!' -path './bin/*' \
+	| entr -c sh -c 'go test -count=1 ./...; date "+%Y/%m/%d %H:%M:%S"'
+

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,18 @@
+# Shared Packages
+
+Reusable Go packages shared across Block Closet services.
+
+## Structure
+
+- `storage/bucket`: S3-compatible bucket name validation exposed via `DefaultBucketNameValidator`.
+
+## Development
+
+### entr
+
+`entr` is used to automatically restart the server and tests when files change.
+Install `entr` with:
+
+```bash
+brew install entr
+```

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,0 +1,3 @@
+module github.com/ratdaddy/blockcloset/pkg
+
+go 1.24.6

--- a/pkg/storage/bucket/validation.go
+++ b/pkg/storage/bucket/validation.go
@@ -1,12 +1,10 @@
-package httpapi
+package bucket
 
 import (
 	"errors"
 	"regexp"
 	"strconv"
 	"strings"
-
-	_ "github.com/ratdaddy/blockcloset/gateway/internal/testutil"
 )
 
 var ErrInvalidBucketName = errors.New("invalid bucket name")

--- a/pkg/storage/bucket/validation_test.go
+++ b/pkg/storage/bucket/validation_test.go
@@ -1,10 +1,10 @@
-package httpapi_test
+package bucket_test
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/ratdaddy/blockcloset/gateway/internal/httpapi"
+	"github.com/ratdaddy/blockcloset/pkg/storage/bucket"
 )
 
 // Bucket name validation tests based on S3 naming rules:
@@ -12,7 +12,7 @@ import (
 
 func TestDefaultBucketNameValidator_GeneralPurposeRules(t *testing.T) {
 	t.Parallel()
-	v := httpapi.DefaultBucketNameValidator{}
+	v := bucket.DefaultBucketNameValidator{}
 
 	type tc struct {
 		name   string
@@ -74,10 +74,10 @@ func TestDefaultBucketNameValidator_GeneralPurposeRules(t *testing.T) {
 			}
 			if !c.wantOK {
 				if err == nil {
-					t.Fatalf("want error %v, got nil", httpapi.ErrInvalidBucketName)
+					t.Fatalf("want error %v, got nil", bucket.ErrInvalidBucketName)
 				}
-				if err != httpapi.ErrInvalidBucketName {
-					t.Fatalf("want %v, got %v", httpapi.ErrInvalidBucketName, err)
+				if err != bucket.ErrInvalidBucketName {
+					t.Fatalf("want %v, got %v", bucket.ErrInvalidBucketName, err)
 				}
 			}
 		})


### PR DESCRIPTION
# Problem

We should probably check that bucket names are valid in gantry too in case there is some other service interfacing with it besides gateway (which already checks for valid bucket names when creating them).

# Solution

Pull the bucket name validator out into a common place and introduce the pkg directory for shared packages. Update gateway to use the validator from there. Add bucket name validation to `CreateBucket` in gantry.