### PR TITLE
Add SQlite and migrations ADRs

### DIFF
--- a/docs/adr/0008-sqlite-for-local-metadata-store.md
+++ b/docs/adr/0008-sqlite-for-local-metadata-store.md
@@ -1,0 +1,41 @@
+# 0008: SQLite for Local Metadata Store
+
+- **Status**: Adopted
+- **Date**: 2025-09-28
+- **Author**: Brian VanLoo
+
+## Context
+
+Each Gantry node in a BlockCloset deployment will need to persist bucket definitions and related metadata so it can operate autonomously while remaining coordinated through Raft replication. Homelab environments favor lightweight dependencies, simple upgrades, and self-contained binaries. The persistence layer must therefore provide durable writes, predictable crash recovery, and minimal operational overhead while aligning with Raft’s single-writer apply loop.
+
+We also need tooling that lets operators inspect data easily using commodity CLI or GUI tools.
+
+## Decision
+
+BlockCloset will store Gantry’s local metadata in [SQLite](https://sqlite.org/), accessed from Go via the [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite) driver. SQLite provides:
+- A transactional, durable single-file database tuned for embedded use.
+- Deterministic behavior compatible with Raft’s single-writer semantics via WAL mode.
+- Broad ecosystem support, making inspection and backups straightforward for homelab operators.
+
+The modernc driver keeps builds CGO-free so binaries cross-compile cleanly and avoid external toolchains, while still tracking upstream SQLite features closely.
+
+## Consequences
+
+- Enables durable local state without introducing an external database dependency.
+- Keeps deployment lightweight: one data file per node plus optional WAL artifacts.
+- Simplifies manual inspection (e.g., via the `sqlite3` CLI or GUI browsers) for troubleshooting upgrades.
+- Requires conscious coordination between migrations and Raft apply logic to avoid long-lived locks.
+- Adds the modernc driver dependency, which may trail official SQLite releases by a short window and has slightly higher CPU cost than CGO builds.
+
+## Alternatives Considered
+
+- **In-memory store**: unsuitable because it loses state on restart and complicates upgrades.
+- **BoltDB/Bbolt**: durable, single-writer friendly, but forces manual serialization strategies and lacks the relational querying flexibility we anticipate needing.
+- **BadgerDB**: high-performance LSM tree with GC overhead; introduces more operational tuning than necessary for the target scale.
+- **Pebble (RocksDB-compatible)**: powerful and battle-tested for large clusters, but heavier to embed and maintain than SQLite for homelab scenarios.
+- **External PostgreSQL/MySQL instance**: would offload storage but adds configuration complexity and breaks the “single binary deployment” goal for homelabs.
+
+## References
+
+- [SQLite Documentation](https://www.sqlite.org/docs.html)
+- [modernc.org/sqlite driver](https://pkg.go.dev/modernc.org/sqlite)

--- a/docs/adr/0009-schema-migrations-with-golang-migrate.md
+++ b/docs/adr/0009-schema-migrations-with-golang-migrate.md
@@ -1,0 +1,39 @@
+# 0008: Schema Migrations with golang-migrate
+
+- **Status**: Adopted
+- **Date**: 2025-09-28
+- **Author**: Brian VanLoo
+
+## Context
+
+Gantry nodes will persist bucket definitions and related metadata locally so they can participate in a Raft cluster while remaining operable in homelab environments. We expect to ship the service with simple installation and maintenance tools that can be upgraded or downgraded without bespoke orchestration. This means every node needs a predictable way to apply schema changes, surface drift, and align its local SQLite database with the version of the running binary.
+
+The migration approach must:
+- Work reliably in constrained homelab deployments where ops tooling may be limited.
+- Support both upgrades and rollbacks between released versions.
+- Integrate cleanly with Go so services can detect schema version mismatches during startup.
+- Avoid coupling the project to environment-specific dependencies (e.g., external migration services).
+
+## Decision
+
+BlockCloset will use [golang-migrate/migrate](https://pkg.go.dev/github.com/golang-migrate/migrate/v4) as the migration engine for SQLite schemas. Migration definitions will be expressed as SQL `up` and `down` files stored in the repository and executed through the migrate CLI or library. Services may run migrations automatically or expose an explicit admin command, but migrate’s version table will remain the single source of truth for schema state.
+
+## Consequences
+
+- Provides a battle-tested mechanism for applying and rolling back migrations, reducing upgrade risk for homelab operators.
+- Keeps migrations as plain SQL so changes remain transparent and reviewable.
+- Enables services to programmatically check schema versions via the migrate library and warn or refuse to start when drift is detected.
+- Introduces a dependency on maintaining paired `up`/`down` scripts; mistakes can make downgrade paths harder.
+- Requires coordination so long-running transactions or Raft apply loops do not hold locks when migrations execute.
+
+## Alternatives Considered
+
+- **pressly/goose**: Simpler CLI with optional Go-based migrations, but lacks broad dialect support and version drift tooling that migrate provides.
+- **ariga/atlas**: Powerful declarative schema management and diffing, yet adds operational complexity and a new DSL that is heavier than needed for BlockCloset’s smaller footprint.
+- **amacneil/dbmate**: CLI-oriented and language-agnostic, but would not integrate as smoothly with Go services for programmatic version checks.
+- **rubenv/sql-migrate**: Embeds migrations in Go and YAML, yet has a smaller community and fewer best-practice patterns for downgrade testing.
+
+## References
+
+- [golang-migrate/migrate](https://github.com/golang-migrate/migrate)
+- [SQLite Write-Ahead Logging](https://www.sqlite.org/wal.html)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,8 @@ Only ADRs in the **Adopted** state appear here.
 | [0005](0005-standardizing-environment-variable-for-application-runtime-mode.md) | Standardizing Environment Variable for Application Runtime Mode | Complete | Establishes a standard environment variable to define the application runtime mode (e.g., development, production). |
 | [0006](0006-structured-logging-with-slog-and-go-chi-httplog.md) | Structured Logging with slog and go-chi/httplog | Complete | Describes the adoption of structured logging using the slog package and integration with go-chi/httplog. |
 | [0007](0007-loggrpc-package-for-grpc-logging.md) | loggrpc Package for gRPC Logging | Complete | Introduces the loggrpc package to facilitate structured logging in gRPC services. |
+| [0008](0008-sqlite-for-local-metadata-store.md) | SQLite for Local Metadata Store | None | Chooses SQLite (via modernc driver) for per-node durable metadata storage. |
+| [0009](0009-schema-migrations-with-golang-migrate.md) | Schema Migrations with golang-migrate | None | Establishes golang-migrate as the standard tool for SQLite schema upgrades and rollbacks. |
 
 ---
 


### PR DESCRIPTION
# Problem

Gantry needs a simple and lightweight datastore

# Solution

Add ADRs explaining SQLite and the database migrations that will be used with it in preparation of creating Gantry's data store.