### PR TITLE
Add CommitObject to flatbed's PutObject operation

### DIFF
--- a/docs/adr/0014-grpc-client-wrapper-testing.md
+++ b/docs/adr/0014-grpc-client-wrapper-testing.md
@@ -45,10 +45,11 @@ Each method test must verify:
    proto request is asserted on the captured call.
 2. **Response mapping** — every field the method maps from the proto response to
    its return value is asserted, confirming correct hydration.
-3. **Request ID propagation** — the test makes two calls: one with a request ID
-   in the context (asserts `x-request-id` metadata is present and correct) and
-   one without (asserts `x-request-id` metadata is absent). There is no separate
-   test file for the interceptor.
+3. **Request ID propagation** — the single call uses a request ID context (via
+   `requestid.WithRequestID`), and the test asserts `x-request-id` metadata is
+   present and correct on the captured call. The absent direction is not tested
+   per method; the interceptor is shared infrastructure and the present-direction
+   assertion is sufficient to confirm it is wired.
 
 ### Fake defaults return meaningful non-zero values
 
@@ -94,5 +95,3 @@ tests that need specific field values).
 
 - [ADR 0012](0012-error-testing-only-for-transformations.md) — error testing scope
 - [ADR 0010](0010-adoption-of-grpc-for-control-plane-api.md) — gRPC adoption
-- `flatbed/internal/gantry/client_test.go`
-- `flatbed/internal/cradle/write_object_test.go`

--- a/flatbed/internal/gantry/client.go
+++ b/flatbed/internal/gantry/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Client struct {
-	buckets servicev1.GantryServiceClient
+	svc servicev1.GantryServiceClient
 	cc      *grpc.ClientConn
 }
 
@@ -29,7 +29,7 @@ func New(ctx context.Context, address string, opts ...grpc.DialOption) (*Client,
 	if err != nil {
 		return nil, err
 	}
-	return &Client{buckets: servicev1.NewGantryServiceClient(cc), cc: cc}, nil
+	return &Client{svc: servicev1.NewGantryServiceClient(cc), cc: cc}, nil
 }
 
 func requestIDUnaryInterceptor() grpc.UnaryClientInterceptor {

--- a/flatbed/internal/gantry/commit_object.go
+++ b/flatbed/internal/gantry/commit_object.go
@@ -1,0 +1,16 @@
+package gantry
+
+import (
+	"context"
+
+	servicev1 "github.com/ratdaddy/blockcloset/proto/gen/gantry/service/v1"
+)
+
+func (c *Client) CommitObject(ctx context.Context, objectID string, size int64, lastModifiedMs int64) error {
+	_, err := c.svc.CommitObject(ctx, &servicev1.CommitObjectRequest{
+		ObjectId:       objectID,
+		Size:           size,
+		LastModifiedMs: lastModifiedMs,
+	})
+	return err
+}

--- a/flatbed/internal/gantry/commit_object_test.go
+++ b/flatbed/internal/gantry/commit_object_test.go
@@ -1,0 +1,44 @@
+package gantry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ratdaddy/blockcloset/flatbed/internal/requestid"
+)
+
+func TestClientCommitObject(t *testing.T) {
+	t.Parallel()
+
+	client, svc := newTestClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	const (
+		objectID         = "test-object-id"
+		size      int64  = 1024
+		lastModMs int64  = 1234567890000
+	)
+
+	if err := client.CommitObject(requestid.WithRequestID(ctx, "req-abc"), objectID, size, lastModMs); err != nil {
+		t.Fatalf("CommitObject: %v", err)
+	}
+
+	call, ok := svc.LastCommitObjectCall()
+	if !ok {
+		t.Fatal("no CommitObject call recorded")
+	}
+	if call.Request.GetObjectId() != objectID {
+		t.Fatalf("request ObjectId = %q, want %q", call.Request.GetObjectId(), objectID)
+	}
+	if call.Request.GetSize() != size {
+		t.Fatalf("request Size = %d, want %d", call.Request.GetSize(), size)
+	}
+	if call.Request.GetLastModifiedMs() != lastModMs {
+		t.Fatalf("request LastModifiedMs = %d, want %d", call.Request.GetLastModifiedMs(), lastModMs)
+	}
+	if meta := call.Metadata.Get("x-request-id"); len(meta) != 1 || meta[0] != "req-abc" {
+		t.Fatalf("x-request-id = %v, want [req-abc]", meta)
+	}
+}

--- a/flatbed/internal/gantry/create_bucket.go
+++ b/flatbed/internal/gantry/create_bucket.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *Client) CreateBucket(ctx context.Context, name string) (string, error) {
-	resp, err := c.buckets.CreateBucket(ctx, &servicev1.CreateBucketRequest{Name: name})
+	resp, err := c.svc.CreateBucket(ctx, &servicev1.CreateBucketRequest{Name: name})
 	if err != nil {
 		return "", err
 	}

--- a/flatbed/internal/gantry/create_bucket_test.go
+++ b/flatbed/internal/gantry/create_bucket_test.go
@@ -35,14 +35,4 @@ func TestClientCreateBucket(t *testing.T) {
 	if meta := call.Metadata.Get("x-request-id"); len(meta) != 1 || meta[0] != "req-abc" {
 		t.Fatalf("x-request-id = %v, want [req-abc]", meta)
 	}
-
-	svc.Reset()
-
-	if _, err := client.CreateBucket(ctx, name); err != nil {
-		t.Fatalf("CreateBucket (no request id): %v", err)
-	}
-	call, _ = svc.LastCreateBucketCall()
-	if meta := call.Metadata.Get("x-request-id"); len(meta) != 0 {
-		t.Fatalf("x-request-id without id = %v, want []", meta)
-	}
 }

--- a/flatbed/internal/gantry/list_buckets.go
+++ b/flatbed/internal/gantry/list_buckets.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *Client) ListBuckets(ctx context.Context) ([]Bucket, error) {
-	resp, err := c.buckets.ListBuckets(ctx, &servicev1.ListBucketsRequest{})
+	resp, err := c.svc.ListBuckets(ctx, &servicev1.ListBucketsRequest{})
 	if err != nil {
 		return nil, err
 	}

--- a/flatbed/internal/gantry/list_buckets_test.go
+++ b/flatbed/internal/gantry/list_buckets_test.go
@@ -48,14 +48,4 @@ func TestClientListBuckets(t *testing.T) {
 	if meta := call.Metadata.Get("x-request-id"); len(meta) != 1 || meta[0] != "req-abc" {
 		t.Fatalf("x-request-id = %v, want [req-abc]", meta)
 	}
-
-	svc.Reset()
-
-	if _, err := client.ListBuckets(ctx); err != nil {
-		t.Fatalf("ListBuckets (no request id): %v", err)
-	}
-	call, _ = svc.LastListBucketsCall()
-	if meta := call.Metadata.Get("x-request-id"); len(meta) != 0 {
-		t.Fatalf("x-request-id without id = %v, want []", meta)
-	}
 }

--- a/flatbed/internal/gantry/plan_write.go
+++ b/flatbed/internal/gantry/plan_write.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *Client) PlanWrite(ctx context.Context, bucket, key string, size int64) (*writeplanv1.WritePlan, error) {
-	resp, err := c.buckets.PlanWrite(ctx, &servicev1.PlanWriteRequest{
+	resp, err := c.svc.PlanWrite(ctx, &servicev1.PlanWriteRequest{
 		Bucket: bucket,
 		Key:    key,
 		Size:   size,

--- a/flatbed/internal/gantry/plan_write_test.go
+++ b/flatbed/internal/gantry/plan_write_test.go
@@ -59,14 +59,4 @@ func TestClientPlanWrite(t *testing.T) {
 	if meta := call.Metadata.Get("x-request-id"); len(meta) != 1 || meta[0] != "req-abc" {
 		t.Fatalf("x-request-id = %v, want [req-abc]", meta)
 	}
-
-	svc.Reset()
-
-	if _, err := client.PlanWrite(ctx, bucket, key, size); err != nil {
-		t.Fatalf("PlanWrite (no request id): %v", err)
-	}
-	call, _ = svc.LastPlanWriteCall()
-	if meta := call.Metadata.Get("x-request-id"); len(meta) != 0 {
-		t.Fatalf("x-request-id without id = %v, want []", meta)
-	}
 }

--- a/flatbed/internal/gantry/test_helpers_test.go
+++ b/flatbed/internal/gantry/test_helpers_test.go
@@ -34,16 +34,22 @@ type planWriteCall struct {
 	Request  *servicev1.PlanWriteRequest
 }
 
+type commitObjectCall struct {
+	Metadata metadata.MD
+	Request  *servicev1.CommitObjectRequest
+}
+
 type captureGantryService struct {
 	servicev1.UnimplementedGantryServiceServer
 
-	mu                 sync.Mutex
-	createBucketCalls  []createBucketCall
-	createBucketHookFn func(context.Context, *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error)
-	listBucketCalls    []listBucketsCall
-	listBucketHookFn   func(context.Context, *servicev1.ListBucketsRequest) (*servicev1.ListBucketsResponse, error)
-	planWriteCalls     []planWriteCall
-	planWriteHookFn    func(context.Context, *servicev1.PlanWriteRequest) (*servicev1.PlanWriteResponse, error)
+	mu                  sync.Mutex
+	createBucketCalls   []createBucketCall
+	createBucketHookFn  func(context.Context, *servicev1.CreateBucketRequest) (*servicev1.CreateBucketResponse, error)
+	listBucketCalls     []listBucketsCall
+	listBucketHookFn    func(context.Context, *servicev1.ListBucketsRequest) (*servicev1.ListBucketsResponse, error)
+	planWriteCalls      []planWriteCall
+	planWriteHookFn     func(context.Context, *servicev1.PlanWriteRequest) (*servicev1.PlanWriteResponse, error)
+	commitObjectCalls   []commitObjectCall
 }
 
 func newCaptureGantryService() *captureGantryService {
@@ -55,6 +61,7 @@ func (s *captureGantryService) Reset() {
 	s.createBucketCalls = nil
 	s.listBucketCalls = nil
 	s.planWriteCalls = nil
+	s.commitObjectCalls = nil
 	s.mu.Unlock()
 }
 
@@ -195,6 +202,31 @@ func (s *captureGantryService) SetPlanWriteHook(fn func(context.Context, *servic
 	s.mu.Lock()
 	s.planWriteHookFn = fn
 	s.mu.Unlock()
+}
+
+func (s *captureGantryService) CommitObject(ctx context.Context, req *servicev1.CommitObjectRequest) (*servicev1.CommitObjectResponse, error) {
+	call := commitObjectCall{
+		Request: proto.Clone(req).(*servicev1.CommitObjectRequest),
+	}
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		call.Metadata = md.Copy()
+	}
+
+	s.mu.Lock()
+	s.commitObjectCalls = append(s.commitObjectCalls, call)
+	s.mu.Unlock()
+
+	return &servicev1.CommitObjectResponse{}, nil
+}
+
+func (s *captureGantryService) LastCommitObjectCall() (commitObjectCall, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.commitObjectCalls) == 0 {
+		return commitObjectCall{}, false
+	}
+	return s.commitObjectCalls[len(s.commitObjectCalls)-1], true
 }
 
 func parseTime(t *testing.T, v string) time.Time {

--- a/flatbed/internal/httpapi/handlers/handlers.go
+++ b/flatbed/internal/httpapi/handlers/handlers.go
@@ -14,6 +14,7 @@ type GantryClient interface {
 	CreateBucket(ctx context.Context, name string) (string, error)
 	ListBuckets(ctx context.Context) ([]gantry.Bucket, error)
 	PlanWrite(ctx context.Context, bucket, key string, size int64) (*writeplanv1.WritePlan, error)
+	CommitObject(ctx context.Context, objectID string, size int64, lastModifiedMs int64) error
 }
 
 // CradleClient defines the operations needed from the Cradle service.

--- a/flatbed/internal/httpapi/handlers/put_object.go
+++ b/flatbed/internal/httpapi/handlers/put_object.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -79,20 +80,26 @@ func (h *Handlers) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.LogWritePlan(r, writePlan.GetObjectId(), writePlan.GetCradleAddress(), contentLength)
+	objectID := writePlan.GetObjectId()
+	cradleAddress := writePlan.GetCradleAddress()
+
+	logger.LogWritePlan(r, objectID, cradleAddress, contentLength)
 
 	// Stream request body to Cradle
-	bytesWritten, _, err := h.Cradle.WriteObject(r.Context(), writePlan.GetCradleAddress(), writePlan.GetObjectId(), bucket, contentLength, r.Body)
-	if err != nil {
-		respond.Error(w, r, "InternalError", http.StatusInternalServerError)
-		return
-	}
+	bytesWritten, lastModifiedMs, err := h.Cradle.WriteObject(r.Context(), cradleAddress, objectID, bucket, contentLength, r.Body)
 
 	// Validate bytes written matches expected size
-	if bytesWritten != contentLength {
+	if err != nil || bytesWritten != contentLength {
 		respond.Error(w, r, "InternalError", http.StatusInternalServerError)
 		return
 	}
 
+	if err := h.Gantry.CommitObject(r.Context(), objectID, bytesWritten, lastModifiedMs); err != nil {
+		respond.Error(w, r, "InternalError", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("ETag", `"`+objectID+`"`)
+	w.Header().Set("Last-Modified", time.UnixMilli(lastModifiedMs).UTC().Format(time.RFC1123))
 	w.WriteHeader(http.StatusOK)
 }

--- a/flatbed/internal/httpapi/handlers/put_object_test.go
+++ b/flatbed/internal/httpapi/handlers/put_object_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -269,6 +270,7 @@ func TestPutObject_CradleIntegration(t *testing.T) {
 		wantCradleSize     int64
 		wantCradleBody     string
 		wantBodySubstr     string
+		wantCommitCalls    int
 	}
 
 	cases := []tc{
@@ -289,6 +291,7 @@ func TestPutObject_CradleIntegration(t *testing.T) {
 			wantCradleBucket:  "photos",
 			wantCradleSize:    17,
 			wantCradleBody:    "test file content",
+			wantCommitCalls:   1,
 		},
 		{
 			name:          "cradle write failure returns 500",
@@ -309,6 +312,7 @@ func TestPutObject_CradleIntegration(t *testing.T) {
 			wantCradleSize:    17,
 			wantCradleBody:    "test file content",
 			wantBodySubstr:    "InternalError",
+			wantCommitCalls:   0,
 		},
 		{
 			name:               "size mismatch returns 500",
@@ -329,6 +333,7 @@ func TestPutObject_CradleIntegration(t *testing.T) {
 			wantCradleSize:     17,
 			wantCradleBody:     "test file content",
 			wantBodySubstr:     "InternalError",
+			wantCommitCalls:    0,
 		},
 	}
 
@@ -396,10 +401,102 @@ func TestPutObject_CradleIntegration(t *testing.T) {
 				}
 			}
 
+			if got := gantryStub.CommitObjectCount(); got != c.wantCommitCalls {
+				t.Fatalf("CommitObject call count: got %d, want %d", got, c.wantCommitCalls)
+			}
+
 			if c.wantBodySubstr != "" {
 				body, _ := io.ReadAll(rec.Body)
 				if !strings.Contains(string(body), c.wantBodySubstr) {
 					t.Fatalf("body: expected substring %q, got %q", c.wantBodySubstr, string(body))
+				}
+			}
+		})
+	}
+}
+
+func TestPutObject_CommitObject(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name           string
+		commitErr      error
+		wantStatus     int
+		wantBodySubstr string
+	}
+
+	cases := []tc{
+		{
+			name:       "successful commit returns 200",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:           "commit failure returns 500",
+			commitErr:      errors.New("gantry unavailable"),
+			wantStatus:     http.StatusInternalServerError,
+			wantBodySubstr: "InternalError",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			gantryStub := testutil.NewGantryStub()
+			cradleStub := testutil.NewCradleStub()
+
+			if c.commitErr != nil {
+				gantryStub.CommitObjectFn = func(context.Context, string, int64, int64) error {
+					return c.commitErr
+				}
+			}
+
+			h := &handlers.Handlers{
+				BucketValidator: validation.DefaultBucketNameValidator{},
+				KeyValidator:    validation.DefaultKeyValidator{},
+				Gantry:          gantryStub,
+				Cradle:          cradleStub,
+			}
+
+			req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader("test file content"))
+			req.SetPathValue("bucket", "photos")
+			req.SetPathValue("key", "vacation.jpg")
+			req.Header.Set("Content-Length", "17")
+			rec := httptest.NewRecorder()
+
+			h.PutObject(rec, req)
+
+			if rec.Code != c.wantStatus {
+				t.Fatalf("status: got %d, want %d", rec.Code, c.wantStatus)
+			}
+
+			if c.wantStatus == http.StatusOK {
+				if got := gantryStub.CommitObjectCount(); got != 1 {
+					t.Fatalf("CommitObject call count: got %d, want 1", got)
+				}
+				call := gantryStub.CommitObjectCalls[0]
+				if call.ObjectID != "stub-object-id" {
+					t.Fatalf("CommitObject ObjectID: got %q, want %q", call.ObjectID, "stub-object-id")
+				}
+				if call.Size != 17 {
+					t.Fatalf("CommitObject Size: got %d, want 17", call.Size)
+				}
+				if call.LastModifiedMs != 1234567890 {
+					t.Fatalf("CommitObject LastModifiedMs: got %d, want 1234567890", call.LastModifiedMs)
+				}
+				if got := rec.Header().Get("ETag"); got != `"stub-object-id"` {
+					t.Fatalf("ETag: got %q, want %q", got, `"stub-object-id"`)
+				}
+				wantLastModified := time.UnixMilli(1234567890).UTC().Format(time.RFC1123)
+				if got := rec.Header().Get("Last-Modified"); got != wantLastModified {
+					t.Fatalf("Last-Modified: got %q, want %q", got, wantLastModified)
+				}
+			}
+
+			if c.wantBodySubstr != "" {
+				body, _ := io.ReadAll(rec.Body)
+				if !strings.Contains(string(body), c.wantBodySubstr) {
+					t.Fatalf("body: expected %q, got %q", c.wantBodySubstr, string(body))
 				}
 			}
 		})

--- a/flatbed/internal/testutil/gantry_stub.go
+++ b/flatbed/internal/testutil/gantry_stub.go
@@ -13,13 +13,21 @@ type PlanWriteCall struct {
 	Size   int64
 }
 
+type CommitObjectCall struct {
+	ObjectID       string
+	Size           int64
+	LastModifiedMs int64
+}
+
 type GantryStub struct {
-	CreateFn       func(context.Context, string) (string, error)
-	ListFn         func(context.Context) ([]gantry.Bucket, error)
-	PlanWriteFn    func(context.Context, string, string, int64) (*writeplanv1.WritePlan, error)
-	CreateCalls    []string
-	ListCalls      int
-	PlanWriteCalls []PlanWriteCall
+	CreateFn          func(context.Context, string) (string, error)
+	ListFn            func(context.Context) ([]gantry.Bucket, error)
+	PlanWriteFn       func(context.Context, string, string, int64) (*writeplanv1.WritePlan, error)
+	CommitObjectFn    func(context.Context, string, int64, int64) error
+	CreateCalls       []string
+	ListCalls         int
+	PlanWriteCalls    []PlanWriteCall
+	CommitObjectCalls []CommitObjectCall
 }
 
 func NewGantryStub() *GantryStub {
@@ -38,6 +46,10 @@ func (g *GantryStub) PlanWriteCount() int {
 	return len(g.PlanWriteCalls)
 }
 
+func (g *GantryStub) CommitObjectCount() int {
+	return len(g.CommitObjectCalls)
+}
+
 func (g *GantryStub) CreateBucket(ctx context.Context, name string) (string, error) {
 	g.CreateCalls = append(g.CreateCalls, name)
 	if g.CreateFn != nil {
@@ -52,6 +64,18 @@ func (g *GantryStub) ListBuckets(ctx context.Context) ([]gantry.Bucket, error) {
 		return g.ListFn(ctx)
 	}
 	return nil, nil
+}
+
+func (g *GantryStub) CommitObject(ctx context.Context, objectID string, size int64, lastModifiedMs int64) error {
+	g.CommitObjectCalls = append(g.CommitObjectCalls, CommitObjectCall{
+		ObjectID:       objectID,
+		Size:           size,
+		LastModifiedMs: lastModifiedMs,
+	})
+	if g.CommitObjectFn != nil {
+		return g.CommitObjectFn(ctx, objectID, size, lastModifiedMs)
+	}
+	return nil
 }
 
 func (g *GantryStub) PlanWrite(ctx context.Context, bucket, key string, size int64) (*writeplanv1.WritePlan, error) {


### PR DESCRIPTION
# Problem

Flatbed needs to call gantry's `CommitObject` once the object has been successfully sent to cradle.

# Solution

Add the `CommitObject` client shim to flatbed and hook up `PutObject` to use it after the `WriteObject` to cradle.